### PR TITLE
More refactoring, use const where let is not needed

### DIFF
--- a/Hive/MongoSchemas/DataChunk.js
+++ b/Hive/MongoSchemas/DataChunk.js
@@ -1,9 +1,9 @@
 'use strict';
 //Import mongoose
-let mongoose = require('mongoose');
+const mongoose = require('mongoose');
 
 //Setup schema
-let dataChunkSchema = mongoose.Schema({
+const dataChunkSchema = mongoose.Schema({
   //data of the DataChunk
   data: String
 });

--- a/Hive/MongoSchemas/WorkGroup.js
+++ b/Hive/MongoSchemas/WorkGroup.js
@@ -1,8 +1,8 @@
 'use strict';
 //Import mongoose, the display manager
-let mongoose = require('mongoose');
+const mongoose = require('mongoose');
 //Create a worker schema for storing clients
-let workGroupSchema = mongoose.Schema({
+const workGroupSchema = mongoose.Schema({
   //Array of objects containing data from each client
   data: [{
     worker: String, //Worker ID

--- a/Hive/MongoSchemas/Worker.js
+++ b/Hive/MongoSchemas/Worker.js
@@ -1,10 +1,10 @@
 'use strict';
 //Import mongoose, the display manager
-let mongoose = require('mongoose');
+const mongoose = require('mongoose');
 //Import forge library for key generation
-let forge = require('node-forge');
+const forge = require('node-forge');
 //Create a worker schema for storing clients
-let workerSchema = mongoose.Schema({
+const workerSchema = mongoose.Schema({
   //For verification
   publicKey: String,
   //Get registration date (future functionality)
@@ -14,7 +14,8 @@ let workerSchema = mongoose.Schema({
 });
 
 //Key generation method
-workerSchema.methods.generateRSAKeyPair = function(callback) {
+workerSchema.methods.generateRSAKeyPair = function(callback) { 
+  // object properties can be added to const variables
   forge.pki.rsa.generateKeyPair({bits: 2048, workers: -1},
     function(error, keypair) {
     if(error == null) {

--- a/Hive/Server/ConnectionHandler.js
+++ b/Hive/Server/ConnectionHandler.js
@@ -1,16 +1,16 @@
 'use strict';
 //Import JsonSocket for easier JSON parsing with net
-let JsonSocket = require('json-socket');
+const JsonSocket = require('json-socket');
 //Import specific message functions
-let register = require('./Register.js');
-let handshake = require('./Handshake.js');
-let verify = require('./Verify.js');
-let request = require('./Request.js');
-let submit = require('./Submit.js');
+const register = require('./Register.js');
+const handshake = require('./Handshake.js');
+const verify = require('./Verify.js');
+const request = require('./Request.js');
+const submit = require('./Submit.js');
 
 
 //Import error handling function
-let errorHandler = require('../../Utils/errorHandler.js');
+const errorHandler = require('../../Utils/errorHandler.js');
 //Export the message handling function
 //mongoose is the mongoose instance which has been configured to the database,
 //Socket is the socket passed by index, eventEmitter is the Event

--- a/Hive/Server/Handshake.js
+++ b/Hive/Server/Handshake.js
@@ -1,11 +1,11 @@
 'use strict';
 //Import forge for encryption
-let forge = require('node-forge');
+const forge = require('node-forge');
 //Import our error handling module
-let errorHandler = require('../../Utils/errorHandler.js');
+const errorHandler = require('../../Utils/errorHandler.js');
 //Import our encryption modules
-let RSA = require('simple-encryption').RSA;
-let AES = require('simple-encryption').AES;
+const RSA = require('simple-encryption').RSA;
+const AES = require('simple-encryption').AES;
 //Should return an AES key
 module.exports = function(message, socket, eventEmitter, key) {
   //If the encrypted payload is not present, fail
@@ -43,7 +43,7 @@ module.exports = function(message, socket, eventEmitter, key) {
     return;
   }
   //Generate a 12 byte IV for AES-GCM
-  let iv = AES.generateIV();
+  const iv = AES.generateIV();
   //Declare encrypted letiable for try/catch
   let encrypted;
   try {

--- a/Hive/Server/Register.js
+++ b/Hive/Server/Register.js
@@ -1,16 +1,16 @@
 'use strict';
 //Import forge
-let forge = require('node-forge');
+const forge = require('node-forge');
 //AES helper
-let AES = require('simple-encryption').AES;
+const AES = require('simple-encryption').AES;
 //Error handler
-let errorHandler = require('../../Utils/errorHandler.js');
+const errorHandler = require('../../Utils/errorHandler.js');
 //Import worker schema in order to register the new worker
-let Worker = require('../MongoSchemas/Worker.js');
+const Worker = require('../MongoSchemas/Worker.js');
 //Export single function for registration
 module.exports = function(message, mongoose, socket, eventEmitter, key) {
   //Create new worker
-  let newWorker = new Worker();
+  const newWorker = new Worker();
   //Create a keypair
   newWorker.generateRSAKeyPair(function(keyPair) {
     //If an error occured when generating the key, tell the user that an error
@@ -22,7 +22,7 @@ module.exports = function(message, mongoose, socket, eventEmitter, key) {
       return;
     }
     //Get the current date
-    let date = new Date();
+    const date = new Date();
     //Export the public key
     newWorker.publicKey = forge.pki.publicKeyToPem(keyPair.publicKey);
     //Set the last active date to the current date
@@ -43,7 +43,7 @@ module.exports = function(message, mongoose, socket, eventEmitter, key) {
         privateKey: forge.pki.privateKeyToPem(keyPair.privateKey)
       };
       //Generate an IV
-      let iv = AES.generateIV();
+      const iv = AES.generateIV();
       //Declare message for try/catch
       let message;
       //Encrypt the message, passing errors to user

--- a/Hive/Server/Request.js
+++ b/Hive/Server/Request.js
@@ -1,20 +1,20 @@
 'use strict';
 //Import error handler
-let errorHandler = require('../../Utils/errorHandler.js');
+const errorHandler = require('../../Utils/errorHandler.js');
 //Import AES library
-let AES = require('simple-encryption').AES;
+const AES = require('simple-encryption').AES;
 
 //Schema imports
-let Worker = require('../MongoSchemas/Worker.js');
-let WorkGroup = require('../MongoSchemas/WorkGroup.js');
+const Worker = require('../MongoSchemas/Worker.js');
+const WorkGroup = require('../MongoSchemas/WorkGroup.js');
 
 //Export the request handler
 module.exports = function(message, mongoose, socket, eventEmitter, key, userID,
   groupMax) {
   //Get encryption information
-  let payload = message.payload;
-  let tag = message.tag;
-  let iv = message.iv;
+  const payload = message.payload;
+  const tag = message.tag;
+  const iv = message.iv;
   //Declare decrypted letiable for try/catch
   let decrypted;
   //Try decrypting, otherwise pass error onto user
@@ -110,7 +110,7 @@ module.exports = function(message, mongoose, socket, eventEmitter, key, userID,
                     return;
                   }
                   //Create and populate the new group
-                  let newworkgroup = new WorkGroup();
+                  const newworkgroup = new WorkGroup();
                   newworkgroup.workers = [userID];
                   newworkgroup.data = [];
                   newworkgroup.work = JSON.stringify(work);
@@ -126,7 +126,7 @@ module.exports = function(message, mongoose, socket, eventEmitter, key, userID,
                       work: work
                     };
                     //Generate IV
-                    let iv = AES.generateIV();
+                    const iv = AES.generateIV();
                     //Declare encrypted letiable for try/catch
                     let encrypted;
                     //Try to encrypt, forward errors
@@ -165,7 +165,7 @@ module.exports = function(message, mongoose, socket, eventEmitter, key, userID,
                     work: JSON.parse(workgroup.work)
                   };
                   //Generate IV
-                  let iv = AES.generateIV();
+                  const iv = AES.generateIV();
                   //Declare encrypted letiable for try/catch block
                   let encrypted;
                   //Attempt to encrypt, pass errors to user

--- a/Hive/Server/Submit.js
+++ b/Hive/Server/Submit.js
@@ -14,21 +14,21 @@
 */
 
 //Import error handler
-let errorHandler = require('../../Utils/errorHandler.js');
+const errorHandler = require('../../Utils/errorHandler.js');
 //Import AES for encryption
-let AES = require('simple-encryption').AES;
+const AES = require('simple-encryption').AES;
 
 //Mongo schemas
-let WorkGroup = require('../MongoSchemas/WorkGroup.js');
-let DataChunk = require('../MongoSchemas/DataChunk.js');
+const WorkGroup = require('../MongoSchemas/WorkGroup.js');
+const DataChunk = require('../MongoSchemas/DataChunk.js');
 
 //Export main submit function
 module.exports = function(message, mongoose, socket, eventEmitter, key, userID,
   groupMax) {
   //Get encryption information
-  let payload = message.payload;
-  let tag = message.tag;
-  let iv = message.iv;
+  const payload = message.payload;
+  const tag = message.tag;
+  const iv = message.iv;
   //Declare decrypted letiable for decryption attempt
   let decrypted;
   //Try to decrypt, pass errors onto user
@@ -47,7 +47,7 @@ module.exports = function(message, mongoose, socket, eventEmitter, key, userID,
     return;
   }
   //Store decrypted json in required locations
-  let data = decrypted.data;
+  const data = decrypted.data;
   //If no data was sent, error
   if(data == null) {
     errorHandler.sendError(socket, 'STAGE_SUBMIT_NO_DATA', true);
@@ -90,11 +90,11 @@ module.exports = function(message, mongoose, socket, eventEmitter, key, userID,
           return;
         }
         //Otherwise alert the user about the success
-        let jsonmsg = {
+        const jsonmsg = {
           success: true
         };
         //Generate an IV
-        let iv = AES.generateIV();
+        const iv = AES.generateIV();
         //Declare encrypted for try/catch
         let encrypted;
         //Try to encrypt

--- a/Hive/Server/Verify.js
+++ b/Hive/Server/Verify.js
@@ -1,23 +1,23 @@
 'use strict';
 //Import encryption functions
-let AES = require('simple-encryption').AES;
-let RSA = require('simple-encryption').RSA;
+const AES = require('simple-encryption').AES;
+const RSA = require('simple-encryption').RSA;
 //Import error handler
-let errorHandler = require('../../Utils/errorHandler.js');
+const errorHandler = require('../../Utils/errorHandler.js');
 //Import forge
-let forge = require('node-forge');
+const forge = require('node-forge');
 
 //Mongoose schemas
-let Worker = require('../MongoSchemas/Worker.js');
+const Worker = require('../MongoSchemas/Worker.js');
 
 module.exports = function(message, mongoose, socket, eventEmitter, key,
   callback) {
   //Supposed user ID
-  let id = message.id;
+  const id = message.id;
   //Get encryption information
-  let payload = message.payload;
-  let iv = message.iv;
-  let tag = message.tag;
+  const payload = message.payload;
+  const iv = message.iv;
+  const tag = message.tag;
   //Define encrypted letiable for try/catch
   let decrypted;
   //Catch any errors during decryption
@@ -37,9 +37,9 @@ module.exports = function(message, mongoose, socket, eventEmitter, key,
     return;
   }
   //Signed payload
-  let verify = decrypted.verify;
+  const verify = decrypted.verify;
   //hash
-  let md = decrypted.md;
+  const md = decrypted.md;
   //Make sure that the required letiables were actually sent
   if(!id || !verify || !md) {
     errorHandler.sendError(socket, 'GENERIC_PARAMETERS_MISSING', true);
@@ -59,7 +59,7 @@ module.exports = function(message, mongoose, socket, eventEmitter, key,
       return;
     }
     //Get the public key for the worker
-    let publicKey = worker.publicKey;
+    const publicKey = worker.publicKey;
     //Declare verified letiable for try/catch
     let verified;
     //Verify that the worker is who they say they are. If verification fails
@@ -72,7 +72,7 @@ module.exports = function(message, mongoose, socket, eventEmitter, key,
       return;
     }
     //Generate IV for encryption
-    let newIV = AES.generateIV();
+    const newIV = AES.generateIV();
     //Create message for encryption
     let jsonmsg = {
       'verified': verified

--- a/Hive/WorkerUtils/WorkerCleaner.js
+++ b/Hive/WorkerUtils/WorkerCleaner.js
@@ -1,7 +1,7 @@
 'use strict';
 //Require Worker and WorkGroup
-let Worker = require('../MongoSchemas/Worker.js');
-let WorkGroup = require('../MongoSchemas/WorkGroup');
+const Worker = require('../MongoSchemas/Worker.js');
+const WorkGroup = require('../MongoSchemas/WorkGroup');
 //Export main function
 module.exports = function(mongoose, settings) {
   //If workTimeout is less than or equal to 0, do not use a timeout
@@ -27,7 +27,7 @@ module.exports = function(mongoose, settings) {
       }
       //Define functions for use within loops
       //Function for database errors in order to tell the user
-      let saveWorkGroup = function(error) {
+      const saveWorkGroup = function(error) {
         //If error, tell the user
         if(error) {
           console.log('Error: DATABASE_GENERIC');
@@ -36,7 +36,7 @@ module.exports = function(mongoose, settings) {
       //Define i for later
       let i = 0;
       //Function for searching workgroups
-      let searchWorkGroup = function(error, workgroups) {
+      const searchWorkGroup = function(error, workgroups) {
         //Check for errors, if so don't continue
         if(error) {
           //Log to the console

--- a/Honeybee/EventHandler.js
+++ b/Honeybee/EventHandler.js
@@ -1,9 +1,9 @@
 'use strict';
 //Import events
-let events = require('events');
+const events = require('events');
 
 //Create EventHandler function
-let EventHandler = function() {
+const EventHandler = function() {
   //Call the EventEmitter constructor on this object
   events.EventEmitter.call(this);
   //Create the registered event

--- a/Honeybee/Handshake.js
+++ b/Honeybee/Handshake.js
@@ -1,15 +1,14 @@
-'use strict';
 //Require the encryption modules
-let RSA = require('simple-encryption').RSA;
-let AES = require('simple-encryption').AES;
+var RSA = require('simple-encryption').RSA;
+var AES = require('simple-encryption').AES;
 //Error handler
-let errorHandler = require('../Utils/errorHandler.js');
+var Error = require('../Utils/errorHandler.js');
 //Export main function
 module.exports = function(socket, serverPublicKey, callback) {
   //Generate a session key
-  let sessionKey = AES.generateKey();
+  var sessionKey = AES.generateKey();
   //Encrypt it with the serverPublicKey
-  let encrypted;
+  var encrypted;
   //Attempt to encrypt, otherwise error to user
   try {
     encrypted = RSA.encrypt(serverPublicKey, JSON.stringify({key: sessionKey}));
@@ -19,16 +18,16 @@ module.exports = function(socket, serverPublicKey, callback) {
   }
   //Listen only once
   socket.once('message', function(message) {
-    if(errorHandler.findError(message.error)) {
+    if(Error.findError(message.error)) {
       //Error has occured
-      console.log('Error: ' + errorHandler.findError(message.error));
+      console.log('Error: ' + Error.findError(message.error));
       return;
     }
-    let payload = message.payload;
-    let tag = message.tag;
-    let iv = message.iv;
+    var payload = message.payload;
+    var tag = message.tag;
+    var iv = message.iv;
     //Try to decrypt
-    let decrypted;
+    var decrypted;
     try {
       decrypted = JSON.parse(AES.decrypt(sessionKey, iv, tag, payload));
     } catch(e) {

--- a/Utils/errorHandler.js
+++ b/Utils/errorHandler.js
@@ -1,6 +1,6 @@
 'use strict';
 //List of errors
-let errors = [
+const errors = [
   //Unknown errors
   'UNKNOWN_ERROR', //ONLY FOR USE IF THE ERROR IS COMPLETELY UNKNOWN
   //Database errors

--- a/examples/client.js
+++ b/examples/client.js
@@ -9,10 +9,10 @@ const PORT = 54321;
 const ADDRESS = 'localhost';
 
 //Import key from filesystem
-let key = fs.readFileSync('public.pem', 'utf8');
+const key = fs.readFileSync('public.pem', 'utf8');
 
 //Define settings object
-let settings = {
+const settings = {
   connection: {
     hostname: 'localhost',
     port: 54321
@@ -26,14 +26,14 @@ let settings = {
 //Create the client, connecting to the server with settings object
 honeybeeHive.Honeybee(settings, function(eventHandler) {
   //Define our submission handler, to handle what happens once we submit work
-  let submitHandler = function(success) {
+  const submitHandler = function(success) {
     //Tell the client the status of our submission
     console.log('Submission ' + (success ? 'succeeded' : 'failed'));
     //Request more work, and pass it to the work handler
     eventHandler.request(workHandler);
   };
   //Define our work handler, to handle what happens when we receive work
-  let workHandler = function(work) {
+  const workHandler = function(work) {
     //Define our piSection letiable, to store the part of pi we calculated
     let piSection = 0;
     //Define n for Leibniz's formula, and calculate current position in it

--- a/examples/server.js
+++ b/examples/server.js
@@ -15,12 +15,12 @@ const GROUP_MAX = 1;  //Amount of clients required to submit data for the work
                       //to be classed as completed
 const FINISH_COUNT = 100; //Amount of jobs to schedule
 //Define counter for amount of work pieces created
-let workCounter = 0;
+let workCounter = 1;
 //Define counter for how many times work has been verified
-let completeCounter = 0;
+const completeCounter = 1;
 
 //Read the PEM encoded private key from the file system
-let serverPrivateKey = fs.readFileSync('private.pem', 'utf8');
+const serverPrivateKey = fs.readFileSync('private.pem', 'utf8');
 //Define pi letiable to store pi for later
 let pi = 0;
 
@@ -47,7 +47,7 @@ let settings = {
   }
 };
 //Start the server
-let eventEmitter = HoneybeeHive.Hive(settings);
+const eventEmitter = HoneybeeHive.Hive(settings);
 //Tell the user that the server has been started
 console.log('Server started');
 //Listen for create work events

--- a/index.js
+++ b/index.js
@@ -2,22 +2,22 @@
 //GENERIC IMPORTS
 //Import event emitter in order for people to be able to listen to events fired
 //by us
-let events = require('events');
+const events = require('events');
 
 //Import deep-defaults, the default settings module
-let defaults = require('deep-defaults');
+const defaults = require('deep-defaults');
 
 //HIVE IMPORTS
 //Import net for JsonSocket
-let net = require('net');
+const net = require('net');
 //Hive connection handler
-let hiveConnectionHandler = require('./Hive/Server/ConnectionHandler.js');
+const hiveConnectionHandler = require('./Hive/Server/ConnectionHandler.js');
 //Import the WorkerCleaner
-let workerCleaner = require('./Hive/WorkerUtils/WorkerCleaner.js');
+const workerCleaner = require('./Hive/WorkerUtils/WorkerCleaner.js');
 //Create the Hive prototype, for the server
-let Hive = function(userSettings) {
+const Hive = function(userSettings) {
   //Set default settings
-  let settings = defaults(userSettings,
+  const settings = defaults(userSettings,
   {
     connection: {
       port: 54321
@@ -43,15 +43,15 @@ let Hive = function(userSettings) {
     }
   });
   //Mongoose
-  let mongoose = require('mongoose');
+  const mongoose = require('mongoose');
   mongoose.Promise = global.Promise;
   mongoose.connect('mongodb://' + settings.database.hostname +
     (settings.database.port ? ':' + settings.database.port : '') +
     '/' + settings.database.databaseName);
   //Create an instance of the event emitter in order to use it later
-  let eventEmitter = new events.EventEmitter();
+  const eventEmitter = new events.EventEmitter();
   //Create a TCP server
-  let server = net.createServer();
+  const server = net.createServer();
   //Listen on the port defined above
   server.listen(settings.connection.port);
   //Start the WorkerCleaner
@@ -68,23 +68,23 @@ let Hive = function(userSettings) {
 
 //HONEYBEE IMPORTS
 //Import Honeybee's ConnectionHandler
-let honeybeeConnectionHandler = require('./Honeybee/ConnectionHandler.js');
+const honeybeeConnectionHandler = require('./Honeybee/ConnectionHandler.js');
 //Import Honeybee's EventHandler
-let HoneybeeEventHandler = require('./Honeybee/EventHandler.js');
+const HoneybeeEventHandler = require('./Honeybee/EventHandler.js');
 //Create Honeybee prototype, for the client
 //address = string hostname of the server
 //port = listening port of the server
 //key = public RSA key of the server
-let Honeybee = function(userSettings, callback) {
+const Honeybee = function(userSettings, callback) {
   //Set default settings
-  let settings = defaults(userSettings, {
+  const settings = defaults(userSettings, {
     connection: {
       hostname: 'localhost',
       port: 54321
     }
   });
   //Create an instance of eventEmitter in order to be able to use it later
-  let eventHandler = new HoneybeeEventHandler();
+  const eventHandler = new HoneybeeEventHandler();
   //Pass the eventHandler back to the client
   callback(eventHandler);
   //Call the connection handler


### PR DESCRIPTION
`const` can be used where a variable is not going to be reassigned, like when `require`'ing something. I replaced all instances of `let` in the Hive folder that do not need to be there. Check #7 
